### PR TITLE
feature/clang tidy linting

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,33 @@
+Checks:          'clang-diagnostic-*,clang-analyzer-*'
+WarningsAsErrors: ''
+HeaderFileExtensions:
+  - ''
+  - h
+  - hh
+  - hpp
+  - hxx
+ImplementationFileExtensions:
+  - c
+  - cc
+  - cpp
+  - cxx
+HeaderFilterRegex: ''
+ExcludeHeaderFilterRegex: ''
+FormatStyle:     none
+User:            ironlung
+CheckOptions:
+  cert-dcl16-c.NewSuffixes: 'L;LL;LU;LLU'
+  cert-err33-c.AllowCastToVoid: 'true'
+  cert-err33-c.CheckedFunctions: '^::aligned_alloc;^::asctime_s;^::at_quick_exit;^::atexit;^::bsearch;^::bsearch_s;^::btowc;^::c16rtomb;^::c32rtomb;^::calloc;^::clock;^::cnd_broadcast;^::cnd_init;^::cnd_signal;^::cnd_timedwait;^::cnd_wait;^::ctime_s;^::fclose;^::fflush;^::fgetc;^::fgetpos;^::fgets;^::fgetwc;^::fopen;^::fopen_s;^::fprintf;^::fprintf_s;^::fputc;^::fputs;^::fputwc;^::fputws;^::fread;^::freopen;^::freopen_s;^::fscanf;^::fscanf_s;^::fseek;^::fsetpos;^::ftell;^::fwprintf;^::fwprintf_s;^::fwrite;^::fwscanf;^::fwscanf_s;^::getc;^::getchar;^::getenv;^::getenv_s;^::gets_s;^::getwc;^::getwchar;^::gmtime;^::gmtime_s;^::localtime;^::localtime_s;^::malloc;^::mbrtoc16;^::mbrtoc32;^::mbsrtowcs;^::mbsrtowcs_s;^::mbstowcs;^::mbstowcs_s;^::memchr;^::mktime;^::mtx_init;^::mtx_lock;^::mtx_timedlock;^::mtx_trylock;^::mtx_unlock;^::printf_s;^::putc;^::putwc;^::raise;^::realloc;^::remove;^::rename;^::scanf;^::scanf_s;^::setlocale;^::setvbuf;^::signal;^::snprintf;^::snprintf_s;^::sprintf;^::sprintf_s;^::sscanf;^::sscanf_s;^::strchr;^::strerror_s;^::strftime;^::strpbrk;^::strrchr;^::strstr;^::strtod;^::strtof;^::strtoimax;^::strtok;^::strtok_s;^::strtol;^::strtold;^::strtoll;^::strtoul;^::strtoull;^::strtoumax;^::strxfrm;^::swprintf;^::swprintf_s;^::swscanf;^::swscanf_s;^::thrd_create;^::thrd_detach;^::thrd_join;^::thrd_sleep;^::time;^::timespec_get;^::tmpfile;^::tmpfile_s;^::tmpnam;^::tmpnam_s;^::tss_create;^::tss_get;^::tss_set;^::ungetc;^::ungetwc;^::vfprintf;^::vfprintf_s;^::vfscanf;^::vfscanf_s;^::vfwprintf;^::vfwprintf_s;^::vfwscanf;^::vfwscanf_s;^::vprintf_s;^::vscanf;^::vscanf_s;^::vsnprintf;^::vsnprintf_s;^::vsprintf;^::vsprintf_s;^::vsscanf;^::vsscanf_s;^::vswprintf;^::vswprintf_s;^::vswscanf;^::vswscanf_s;^::vwprintf_s;^::vwscanf;^::vwscanf_s;^::wcrtomb;^::wcschr;^::wcsftime;^::wcspbrk;^::wcsrchr;^::wcsrtombs;^::wcsrtombs_s;^::wcsstr;^::wcstod;^::wcstof;^::wcstoimax;^::wcstok;^::wcstok_s;^::wcstol;^::wcstold;^::wcstoll;^::wcstombs;^::wcstombs_s;^::wcstoul;^::wcstoull;^::wcstoumax;^::wcsxfrm;^::wctob;^::wctrans;^::wctype;^::wmemchr;^::wprintf_s;^::wscanf;^::wscanf_s;'
+  cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField: 'false'
+  cert-str34-c.DiagnoseSignedUnsignedCharComparisons: 'false'
+  cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic: 'true'
+  google-readability-braces-around-statements.ShortStatementLines: '1'
+  google-readability-function-size.StatementThreshold: '800'
+  google-readability-namespace-comments.ShortNamespaceLines: '10'
+  google-readability-namespace-comments.SpacesBeforeComments: '2'
+  llvm-else-after-return.WarnOnConditionVariables: 'false'
+  llvm-else-after-return.WarnOnUnfixable: 'false'
+  llvm-qualified-auto.AddConstToQualified: 'false'
+SystemHeaders:   false
+

--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,26 @@
+CompileFlags:
+  Add: [
+    -DSSIZE_MAX,
+    -DLWIP_NO_UNISTD_H=1,
+    -Dssize_t=long,
+    -D_SSIZE_T_DECLARED,
+    -Wno-unknown-warning-option
+  ]
+  Remove: [
+    -mlong-calls,
+    -fno-tree-switch-conversion,
+    -mtext-section-literals,
+    -mlongcalls,
+    -fstrict-volatile-bitfields,
+    -free,
+    -fipa-pta,
+    -march=*,
+    -mabi=*,
+    -mcpu=*
+  ]
+Diagnostics:
+  Suppress:
+    - pp_including_mainfile_in_preamble
+    - pp_expr_bad_token_start_expr
+    - redefinition_different_typedef
+    - main_returns_nonint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,11 +2,7 @@ name: Build hardware firmware
 
 on:
   push:
-    branches:
-      - "*"
   pull_request:
-    branches:
-      - "*"
   workflow_dispatch:
 
 jobs:
@@ -17,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cache pip
         uses: actions/cache@v4
@@ -57,4 +53,3 @@ jobs:
         run: |
           cd src_package_arduino
           platformio run -e uno_r4_wifi
-        

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: "clang-format lint"
         uses: DoozyX/clang-format-lint-action@v0.20

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,53 @@
+name: PlatformIO Lint check
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Cache PlatformIO
+        uses: actions/cache@v4
+        with:
+          path: ~/.platformio
+          key: ${{ runner.os }}-${{ hashFiles('**/platformio.ini') }}
+          restore-keys: |
+            ${{ runner.os }}-
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install PlatformIO
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade platformio
+
+      - name: Check broker firmware
+        shell: bash
+        run: |
+          cd src_broker_esp32
+          platformio check -e esp32_broker
+
+      - name: Check package firmware
+        shell: bash
+        run: |
+          cd src_package_arduino
+          platformio check -e uno_r4_wifi

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,13 +9,13 @@ on:
       - "*"
   workflow_dispatch:
 
-jobs: 
+jobs:
   runUnitTests:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cache pip
         uses: actions/cache@v4
@@ -37,13 +37,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-      
+
       - name: Install PlatformIO
         shell: bash
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade platformio
-      
+
       - name: Run native unit tests
         shell: bash
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,6 @@
 .cache
 
 # ignore compile-commands
-**/compile_commands.json
+**/compile_commands.json*
 
 **/.vscode/

--- a/src_broker_esp32/.clang-tidy
+++ b/src_broker_esp32/.clang-tidy
@@ -1,0 +1,33 @@
+Checks:          'clang-diagnostic-*,clang-analyzer-*'
+WarningsAsErrors: ''
+HeaderFileExtensions:
+  - ''
+  - h
+  - hh
+  - hpp
+  - hxx
+ImplementationFileExtensions:
+  - c
+  - cc
+  - cpp
+  - cxx
+HeaderFilterRegex: ''
+ExcludeHeaderFilterRegex: ''
+FormatStyle:     none
+User:            ironlung
+CheckOptions:
+  cert-dcl16-c.NewSuffixes: 'L;LL;LU;LLU'
+  cert-err33-c.AllowCastToVoid: 'true'
+  cert-err33-c.CheckedFunctions: '^::aligned_alloc;^::asctime_s;^::at_quick_exit;^::atexit;^::bsearch;^::bsearch_s;^::btowc;^::c16rtomb;^::c32rtomb;^::calloc;^::clock;^::cnd_broadcast;^::cnd_init;^::cnd_signal;^::cnd_timedwait;^::cnd_wait;^::ctime_s;^::fclose;^::fflush;^::fgetc;^::fgetpos;^::fgets;^::fgetwc;^::fopen;^::fopen_s;^::fprintf;^::fprintf_s;^::fputc;^::fputs;^::fputwc;^::fputws;^::fread;^::freopen;^::freopen_s;^::fscanf;^::fscanf_s;^::fseek;^::fsetpos;^::ftell;^::fwprintf;^::fwprintf_s;^::fwrite;^::fwscanf;^::fwscanf_s;^::getc;^::getchar;^::getenv;^::getenv_s;^::gets_s;^::getwc;^::getwchar;^::gmtime;^::gmtime_s;^::localtime;^::localtime_s;^::malloc;^::mbrtoc16;^::mbrtoc32;^::mbsrtowcs;^::mbsrtowcs_s;^::mbstowcs;^::mbstowcs_s;^::memchr;^::mktime;^::mtx_init;^::mtx_lock;^::mtx_timedlock;^::mtx_trylock;^::mtx_unlock;^::printf_s;^::putc;^::putwc;^::raise;^::realloc;^::remove;^::rename;^::scanf;^::scanf_s;^::setlocale;^::setvbuf;^::signal;^::snprintf;^::snprintf_s;^::sprintf;^::sprintf_s;^::sscanf;^::sscanf_s;^::strchr;^::strerror_s;^::strftime;^::strpbrk;^::strrchr;^::strstr;^::strtod;^::strtof;^::strtoimax;^::strtok;^::strtok_s;^::strtol;^::strtold;^::strtoll;^::strtoul;^::strtoull;^::strtoumax;^::strxfrm;^::swprintf;^::swprintf_s;^::swscanf;^::swscanf_s;^::thrd_create;^::thrd_detach;^::thrd_join;^::thrd_sleep;^::time;^::timespec_get;^::tmpfile;^::tmpfile_s;^::tmpnam;^::tmpnam_s;^::tss_create;^::tss_get;^::tss_set;^::ungetc;^::ungetwc;^::vfprintf;^::vfprintf_s;^::vfscanf;^::vfscanf_s;^::vfwprintf;^::vfwprintf_s;^::vfwscanf;^::vfwscanf_s;^::vprintf_s;^::vscanf;^::vscanf_s;^::vsnprintf;^::vsnprintf_s;^::vsprintf;^::vsprintf_s;^::vsscanf;^::vsscanf_s;^::vswprintf;^::vswprintf_s;^::vswscanf;^::vswscanf_s;^::vwprintf_s;^::vwscanf;^::vwscanf_s;^::wcrtomb;^::wcschr;^::wcsftime;^::wcspbrk;^::wcsrchr;^::wcsrtombs;^::wcsrtombs_s;^::wcsstr;^::wcstod;^::wcstof;^::wcstoimax;^::wcstok;^::wcstok_s;^::wcstol;^::wcstold;^::wcstoll;^::wcstombs;^::wcstombs_s;^::wcstoul;^::wcstoull;^::wcstoumax;^::wcsxfrm;^::wctob;^::wctrans;^::wctype;^::wmemchr;^::wprintf_s;^::wscanf;^::wscanf_s;'
+  cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField: 'false'
+  cert-str34-c.DiagnoseSignedUnsignedCharComparisons: 'false'
+  cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic: 'true'
+  google-readability-braces-around-statements.ShortStatementLines: '1'
+  google-readability-function-size.StatementThreshold: '800'
+  google-readability-namespace-comments.ShortNamespaceLines: '10'
+  google-readability-namespace-comments.SpacesBeforeComments: '2'
+  llvm-else-after-return.WarnOnConditionVariables: 'false'
+  llvm-else-after-return.WarnOnUnfixable: 'false'
+  llvm-qualified-auto.AddConstToQualified: 'false'
+SystemHeaders:   false
+

--- a/src_broker_esp32/.clangd
+++ b/src_broker_esp32/.clangd
@@ -1,0 +1,26 @@
+CompileFlags:
+  Add: [
+    -DSSIZE_MAX,
+    -DLWIP_NO_UNISTD_H=1,
+    -Dssize_t=long,
+    -D_SSIZE_T_DECLARED,
+    -Wno-unknown-warning-option
+  ]
+  Remove: [
+    -mlong-calls,
+    -fno-tree-switch-conversion,
+    -mtext-section-literals,
+    -mlongcalls,
+    -fstrict-volatile-bitfields,
+    -free,
+    -fipa-pta,
+    -march=*,
+    -mabi=*,
+    -mcpu=*
+  ]
+Diagnostics:
+  Suppress:
+    - pp_including_mainfile_in_preamble
+    - pp_expr_bad_token_start_expr
+    - redefinition_different_typedef
+    - main_returns_nonint

--- a/src_broker_esp32/cli.sh
+++ b/src_broker_esp32/cli.sh
@@ -2,11 +2,11 @@
 # Simple script for switching clang between boards and different compile_commands on CLI
 
 PARAMETER=$1
-BOARD=$2
+ENV=$2
 
 if [ "$ENV" == "default" ]; then
-  BOARD="esp32_broker"
-elif [ "$BOARD" == "fredrik" ]; then
+  ENV="esp32_broker"
+elif [ "$ENV" == "fredrik" ]; then
   ENV="esp32_broker_fredrik"
 fi
 

--- a/src_broker_esp32/cli.sh
+++ b/src_broker_esp32/cli.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Simple script for switching clang between boards and different compile_commands on CLI
+
+PARAMETER=$1
+BOARD=$2
+
+if [ "$ENV" == "default" ]; then
+  BOARD="esp32_broker"
+elif [ "$BOARD" == "fredrik" ]; then
+  ENV="uno_r4_wifi"
+fi
+
+init() {
+  echo "Initializing PlatformIO CLI..."
+  if [ -z "$ENV" ]; then
+    pio init --ide vim && pio run -t compiledb -e uno_r4_wifi
+  else
+    pio init --ide vim && pio run -t compiledb -e "$ENV"
+  fi
+}
+
+compiledb() {
+  echo "Generating compile commands database..."
+  pio run -t compiledb
+}
+
+convert() {
+  echo -n "Converting compile_commands.json to alternate format.."
+  python3 ../tools/convert.py
+  echo "...done"
+}
+
+usage() {
+  echo "Usage: $0 [init|compiledb]"
+}
+
+if [ "$PARAMETER" == "init" ]; then
+  init
+elif [ "$PARAMETER" == "compiledb" ]; then
+  compiledb
+elif [ "$PARAMETER" == "convert" ]; then
+  convert
+else
+  usage
+  exit 1
+fi

--- a/src_broker_esp32/cli.sh
+++ b/src_broker_esp32/cli.sh
@@ -7,13 +7,13 @@ BOARD=$2
 if [ "$ENV" == "default" ]; then
   BOARD="esp32_broker"
 elif [ "$BOARD" == "fredrik" ]; then
-  ENV="uno_r4_wifi"
+  ENV="esp32_broker_fredrik"
 fi
 
 init() {
   echo "Initializing PlatformIO CLI..."
   if [ -z "$ENV" ]; then
-    pio init --ide vim && pio run -t compiledb -e uno_r4_wifi
+    pio init --ide vim && pio run -t compiledb -e esp32_broker
   else
     pio init --ide vim && pio run -t compiledb -e "$ENV"
   fi

--- a/src_broker_esp32/cli.sh
+++ b/src_broker_esp32/cli.sh
@@ -31,7 +31,7 @@ convert() {
 }
 
 usage() {
-  echo "Usage: $0 [init|compiledb]"
+  echo "Usage: $0 [init|compiledb|convert]"
 }
 
 if [ "$PARAMETER" == "init" ]; then

--- a/src_broker_esp32/platformio.ini
+++ b/src_broker_esp32/platformio.ini
@@ -23,7 +23,7 @@ build_flags =
 #extra_scripts = pre:merge_compiledb.py
 check_tool = clangtidy
 check_flags =
-  clangtidy: --checks=-*,cert-*,clang-analyzer-* --fix'
+  clangtidy: --checks=-*,cert-*,clang-analyzer-* --fix
 
 [env:esp32_broker_fredrik]
 platform = espressif32
@@ -32,4 +32,4 @@ framework = arduino
 board_build.mcu = esp32
 check_tool = clangtidy
 check_flags =
-  clangtidy: --checks=-*,cert-*,clang-analyzer-* --fix'
+  clangtidy: --checks=-*,cert-*,clang-analyzer-* --fix

--- a/src_broker_esp32/platformio.ini
+++ b/src_broker_esp32/platformio.ini
@@ -21,10 +21,15 @@ build_flags =
 #lib_deps =
 #    ../lib/shared
 #extra_scripts = pre:merge_compiledb.py
+check_tool = clangtidy
+check_flags =
+  clangtidy: --checks=-*,cert-*,clang-analyzer-* --fix'
 
 [env:esp32_broker_fredrik]
 platform = espressif32
 board = esp32dev
 framework = arduino
 board_build.mcu = esp32
-
+check_tool = clangtidy
+check_flags =
+  clangtidy: --checks=-*,cert-*,clang-analyzer-* --fix'

--- a/src_package_arduino/.clang-tidy
+++ b/src_package_arduino/.clang-tidy
@@ -1,0 +1,33 @@
+Checks:          'clang-diagnostic-*,clang-analyzer-*'
+WarningsAsErrors: ''
+HeaderFileExtensions:
+  - ''
+  - h
+  - hh
+  - hpp
+  - hxx
+ImplementationFileExtensions:
+  - c
+  - cc
+  - cpp
+  - cxx
+HeaderFilterRegex: ''
+ExcludeHeaderFilterRegex: ''
+FormatStyle:     none
+User:            ironlung
+CheckOptions:
+  cert-dcl16-c.NewSuffixes: 'L;LL;LU;LLU'
+  cert-err33-c.AllowCastToVoid: 'true'
+  cert-err33-c.CheckedFunctions: '^::aligned_alloc;^::asctime_s;^::at_quick_exit;^::atexit;^::bsearch;^::bsearch_s;^::btowc;^::c16rtomb;^::c32rtomb;^::calloc;^::clock;^::cnd_broadcast;^::cnd_init;^::cnd_signal;^::cnd_timedwait;^::cnd_wait;^::ctime_s;^::fclose;^::fflush;^::fgetc;^::fgetpos;^::fgets;^::fgetwc;^::fopen;^::fopen_s;^::fprintf;^::fprintf_s;^::fputc;^::fputs;^::fputwc;^::fputws;^::fread;^::freopen;^::freopen_s;^::fscanf;^::fscanf_s;^::fseek;^::fsetpos;^::ftell;^::fwprintf;^::fwprintf_s;^::fwrite;^::fwscanf;^::fwscanf_s;^::getc;^::getchar;^::getenv;^::getenv_s;^::gets_s;^::getwc;^::getwchar;^::gmtime;^::gmtime_s;^::localtime;^::localtime_s;^::malloc;^::mbrtoc16;^::mbrtoc32;^::mbsrtowcs;^::mbsrtowcs_s;^::mbstowcs;^::mbstowcs_s;^::memchr;^::mktime;^::mtx_init;^::mtx_lock;^::mtx_timedlock;^::mtx_trylock;^::mtx_unlock;^::printf_s;^::putc;^::putwc;^::raise;^::realloc;^::remove;^::rename;^::scanf;^::scanf_s;^::setlocale;^::setvbuf;^::signal;^::snprintf;^::snprintf_s;^::sprintf;^::sprintf_s;^::sscanf;^::sscanf_s;^::strchr;^::strerror_s;^::strftime;^::strpbrk;^::strrchr;^::strstr;^::strtod;^::strtof;^::strtoimax;^::strtok;^::strtok_s;^::strtol;^::strtold;^::strtoll;^::strtoul;^::strtoull;^::strtoumax;^::strxfrm;^::swprintf;^::swprintf_s;^::swscanf;^::swscanf_s;^::thrd_create;^::thrd_detach;^::thrd_join;^::thrd_sleep;^::time;^::timespec_get;^::tmpfile;^::tmpfile_s;^::tmpnam;^::tmpnam_s;^::tss_create;^::tss_get;^::tss_set;^::ungetc;^::ungetwc;^::vfprintf;^::vfprintf_s;^::vfscanf;^::vfscanf_s;^::vfwprintf;^::vfwprintf_s;^::vfwscanf;^::vfwscanf_s;^::vprintf_s;^::vscanf;^::vscanf_s;^::vsnprintf;^::vsnprintf_s;^::vsprintf;^::vsprintf_s;^::vsscanf;^::vsscanf_s;^::vswprintf;^::vswprintf_s;^::vswscanf;^::vswscanf_s;^::vwprintf_s;^::vwscanf;^::vwscanf_s;^::wcrtomb;^::wcschr;^::wcsftime;^::wcspbrk;^::wcsrchr;^::wcsrtombs;^::wcsrtombs_s;^::wcsstr;^::wcstod;^::wcstof;^::wcstoimax;^::wcstok;^::wcstok_s;^::wcstol;^::wcstold;^::wcstoll;^::wcstombs;^::wcstombs_s;^::wcstoul;^::wcstoull;^::wcstoumax;^::wcsxfrm;^::wctob;^::wctrans;^::wctype;^::wmemchr;^::wprintf_s;^::wscanf;^::wscanf_s;'
+  cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField: 'false'
+  cert-str34-c.DiagnoseSignedUnsignedCharComparisons: 'false'
+  cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic: 'true'
+  google-readability-braces-around-statements.ShortStatementLines: '1'
+  google-readability-function-size.StatementThreshold: '800'
+  google-readability-namespace-comments.ShortNamespaceLines: '10'
+  google-readability-namespace-comments.SpacesBeforeComments: '2'
+  llvm-else-after-return.WarnOnConditionVariables: 'false'
+  llvm-else-after-return.WarnOnUnfixable: 'false'
+  llvm-qualified-auto.AddConstToQualified: 'false'
+SystemHeaders:   false
+

--- a/src_package_arduino/.clangd
+++ b/src_package_arduino/.clangd
@@ -1,0 +1,26 @@
+CompileFlags:
+  Add: [
+    -DSSIZE_MAX,
+    -DLWIP_NO_UNISTD_H=1,
+    -Dssize_t=long,
+    -D_SSIZE_T_DECLARED,
+    -Wno-unknown-warning-option
+  ]
+  Remove: [
+    -mlong-calls,
+    -fno-tree-switch-conversion,
+    -mtext-section-literals,
+    -mlongcalls,
+    -fstrict-volatile-bitfields,
+    -free,
+    -fipa-pta,
+    -march=*,
+    -mabi=*,
+    -mcpu=*
+  ]
+Diagnostics:
+  Suppress:
+    - pp_including_mainfile_in_preamble
+    - pp_expr_bad_token_start_expr
+    - redefinition_different_typedef
+    - main_returns_nonint

--- a/src_package_arduino/cli.sh
+++ b/src_package_arduino/cli.sh
@@ -29,7 +29,7 @@ convert() {
 }
 
 usage() {
-  echo "Usage: $0 [init|compiledb]"
+  echo "Usage: $0 [init|compiledb|convert]"
 }
 
 if [ "$PARAMETER" == "init" ]; then

--- a/src_package_arduino/cli.sh
+++ b/src_package_arduino/cli.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Simple script for switching clang between boards and different compile_commands on CLI
+
+PARAMETER=$1
+BOARD=$2
+
+if [ "$ENV" == "default" ]; then
+  BOARD="uno_r4_wifi"
+fi
+
+init() {
+  echo "Initializing PlatformIO CLI..."
+  if [ -z "$ENV" ]; then
+    pio init --ide vim && pio run -t compiledb -e uno_r4_wifi
+  else
+    pio init --ide vim && pio run -t compiledb -e "$ENV"
+  fi
+}
+
+compiledb() {
+  echo "Generating compile commands database..."
+  pio run -t compiledb
+}
+
+convert() {
+  echo -n "Converting compile_commands.json to alternate format.."
+  python3 ../tools/convert.py
+  echo "...done"
+}
+
+usage() {
+  echo "Usage: $0 [init|compiledb]"
+}
+
+if [ "$PARAMETER" == "init" ]; then
+  init
+elif [ "$PARAMETER" == "compiledb" ]; then
+  compiledb
+elif [ "$PARAMETER" == "convert" ]; then
+  convert
+else
+  usage
+  exit 1
+fi

--- a/src_package_arduino/cli.sh
+++ b/src_package_arduino/cli.sh
@@ -2,10 +2,10 @@
 # Simple script for switching clang between boards and different compile_commands on CLI
 
 PARAMETER=$1
-BOARD=$2
+ENV=$2
 
 if [ "$ENV" == "default" ]; then
-  BOARD="uno_r4_wifi"
+  ENV="uno_r4_wifi"
 fi
 
 init() {

--- a/src_package_arduino/platformio.ini
+++ b/src_package_arduino/platformio.ini
@@ -15,6 +15,9 @@ default_envs = uno_r4_wifi
 platform = renesas-ra
 board = uno_r4_wifi
 framework = arduino
+check_tool = clangtidy
+check_flags =
+  clangtidy: --checks=-*,cert-*,clang-analyzer-* --fix'
 lib_deps = adafruit/DHT sensor library@^1.4.6
 
 ; test environment for PC

--- a/src_package_arduino/platformio.ini
+++ b/src_package_arduino/platformio.ini
@@ -17,7 +17,7 @@ board = uno_r4_wifi
 framework = arduino
 check_tool = clangtidy
 check_flags =
-  clangtidy: --checks=-*,cert-*,clang-analyzer-* --fix'
+  clangtidy: --checks=-*,cert-*,clang-analyzer-* --fix
 lib_deps = adafruit/DHT sensor library@^1.4.6
 
 ; test environment for PC

--- a/tools/convert.py
+++ b/tools/convert.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+import json
+import subprocess
+from pathlib import Path
+
+# Constants
+PROJECT_ROOT = Path.cwd()
+SRC_FILE = PROJECT_ROOT / "src" / "main.cpp"
+CCDB_ORIG = PROJECT_ROOT / "compile_commands.json"
+CCDB_BAK = PROJECT_ROOT / "compile_commands.json.bak"
+CCLS_FILE = PROJECT_ROOT / ".ccls"
+CCDB_NEW = PROJECT_ROOT / "compile_commands.json"
+
+KEEP_FLAGS = ("-I", "-D", "-std", "-Wall")
+
+
+def ensure_compile_commands():
+    if not CCDB_ORIG.exists():
+        subprocess.run(["pio", "run", "-t", "compiledb"], check=True)
+    if not CCDB_BAK.exists():
+        CCDB_ORIG.rename(CCDB_BAK)
+
+
+def extract_compiler():
+    return "g++"
+
+
+def parse_ccls():
+    common_flags = []
+    cpp_flags = []
+    with open(CCLS_FILE) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("%cpp"):
+                cpp_flags.extend(
+                    [
+                        flag
+                        for flag in line.split()[1:]
+                        if flag == "-Wall" or flag.startswith(KEEP_FLAGS)
+                    ]
+                )
+            elif line.startswith("%c"):
+                pass  # skip C files for now
+            elif not line.startswith("%"):
+                common_flags.extend(
+                    [
+                        flag
+                        for flag in line.split()
+                        if flag == "-Wall" or flag.startswith(KEEP_FLAGS)
+                    ]
+                )
+    return common_flags + cpp_flags
+
+
+def generate_single_entry_compile_command(compiler, flags):
+    entry = {
+        "directory": str(PROJECT_ROOT),
+        "file": str(SRC_FILE),
+        "command": f"{compiler} {' '.join(flags)} {SRC_FILE}",
+    }
+    CCDB_NEW.write_text(json.dumps([entry], indent=2))
+    return 1
+
+
+# Execution
+ensure_compile_commands()
+compiler_path = extract_compiler()
+filtered_flags = parse_ccls()
+entry_count = generate_single_entry_compile_command(compiler_path, filtered_flags)


### PR DESCRIPTION
- **Alternate script for creating compile_commands**
- **Add clang files**
- **Ignore compile_commands backup files**
- **Small simplification and upgrade checkout**
- **Simple script for CLI clangd use**
- **Initial PlatformIO lint check with clang-tidy**
- **Check options for clang-tidy**

## Summary
Adds a pipeline for PlatformIO linting and also simple scripts for generating compile_commands.json for CLI use.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Infrastructure/DevOps
- [ ] Other (please describe):

## Testing
Explain how you tested this change.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing (local)
- [ ] Built & ran Docker image(s)
- [ ] Verified docker-compose setup
- [ ] Tested in Azure staging environment

## Checklist
- [ ] Code follows project guidelines
- [x] I’ve tested my changes locally
- [ ] I’ve updated docs/configs (if needed)
- [x] No new warnings or errors
- [ ] Relevant tests added/updated
- [ ] Dockerfiles / Compose updated if needed
- [ ] Azure pipelines / IaC updated if needed
